### PR TITLE
log: add licenses to submodules

### DIFF
--- a/log/LICENSE.txt
+++ b/log/LICENSE.txt
@@ -1,0 +1,1 @@
+LICENSE.txt

--- a/log/log15adapter/LICENSE.txt
+++ b/log/log15adapter/LICENSE.txt
@@ -1,0 +1,1 @@
+LICENSE.txt

--- a/log/pgxadapter/LICENSE.txt
+++ b/log/pgxadapter/LICENSE.txt
@@ -1,0 +1,1 @@
+LICENSE.txt


### PR DESCRIPTION
Currently, if you go to https://pkg.go.dev/github.com/ngrok/libngrok-go/log, you get "Documentation not displayed due to license restrictions."

I'm hopeful that this will fix it.

I've tested this by using `go run golang.org/x/pkgsite/cmd/pkgsite` to run it locally and verified that the 'log' submodule has the little 'Redistributable License' tickmark on it with this change.